### PR TITLE
비즈니스 키 생성용 random id generator 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/justcodeit/moyeo/study/RandomIdUtil.java
+++ b/src/main/java/com/justcodeit/moyeo/study/RandomIdUtil.java
@@ -1,0 +1,20 @@
+package com.justcodeit.moyeo.study;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RandomIdUtil {
+  private static final int counterMax = 256 * 256;
+  private static final AtomicInteger intVal = new AtomicInteger(0);
+
+  private static String generate() {
+    final long uid = Instant.now().toEpochMilli() * counterMax + intVal.accumulateAndGet(1, (index, inc) -> (index + inc) % counterMax);
+
+    return Long.toHexString(uid);
+  }
+
+  public String next() {
+    return generate();
+  }
+
+}

--- a/src/test/java/com/justcodeit/moyeo/study/RandomIdUtilTest.java
+++ b/src/test/java/com/justcodeit/moyeo/study/RandomIdUtilTest.java
@@ -1,0 +1,61 @@
+package com.justcodeit.moyeo.study;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+class RandomIdUtilTest {
+
+  @Test
+  void testNext() {
+    var randomIdUtil = new RandomIdUtil();
+    String result = randomIdUtil.next();
+    Assertions.assertNotNull(result);
+
+    int times = 5000;
+    Set<String> set = new HashSet<String>();
+    for (int i = 0; i < times; i++) {
+      set.add(randomIdUtil.next());
+    }
+    Assertions.assertEquals(times, set.size());
+  }
+
+  @Test
+  void multiThreadTest() {
+    final var u = new RandomIdUtil();
+    Supplier<List<String>> testCallback = () -> {
+      var l = new ArrayList<String>();
+      for (int i = 0; i < 10000; i++) {
+        String id = u.next();
+        l.add(id);
+//        log.debug(id);
+      }
+      return l;
+    };
+    var executor = Executors.newFixedThreadPool(3);
+    CompletableFuture<List<String>> f1 = CompletableFuture.supplyAsync(testCallback, executor);
+    CompletableFuture<List<String>> f2 = CompletableFuture.supplyAsync(testCallback, executor);
+    CompletableFuture<List<String>> f3 = CompletableFuture.supplyAsync(testCallback, executor);
+    CompletableFuture<List<String>> f4 = CompletableFuture.supplyAsync(testCallback, executor);
+    CompletableFuture.allOf(f1, f2, f3, f4);
+    log.debug("all works over");
+    var resultList = Stream.of(f1, f2, f3, f4).map(CompletableFuture::join).flatMap(List::stream)
+        .collect(Collectors.toList());
+    var resultSet = new HashSet<>(resultList);
+
+    Assertions.assertEquals(10000*4, resultSet.size());
+
+  }
+}


### PR DESCRIPTION
다용도로 사용할수 있는 random id generator 추가
security 관련 pr에서 구조의 변경이 많이 있었으므로 충돌을 피하기 위해 루트에 생성함
추후 적절한 패키지로의 이동 필요함
빈으로 생성후 di 받아 사용 할것
멀티스레드 환경에서의 duplicate 문제를 확인하기 위한 테스트 추가함