### PR TITLE
Feature/221018 post search

### DIFF
--- a/src/main/java/com/justcodeit/moyeo/study/application/post/PostService.java
+++ b/src/main/java/com/justcodeit/moyeo/study/application/post/PostService.java
@@ -4,6 +4,7 @@ import com.justcodeit.moyeo.study.application.skill.exception.SkillCannotFoundEx
 import com.justcodeit.moyeo.study.interfaces.dto.post.CardResDto;
 import com.justcodeit.moyeo.study.interfaces.dto.post.PostCreateReqDto;
 import com.justcodeit.moyeo.study.interfaces.dto.post.PostResDto;
+import com.justcodeit.moyeo.study.interfaces.dto.post.PostSearchCondition;
 import com.justcodeit.moyeo.study.interfaces.mapper.PostMapper;
 import com.justcodeit.moyeo.study.persistence.Post;
 import com.justcodeit.moyeo.study.persistence.PostSkill;
@@ -25,10 +26,8 @@ import java.util.stream.Collectors;
 public class PostService {
 
     private final PostRepository postRepository;
-    private final PostSkillRepository postSkillRepository;
     private final SkillRepository skillRepository;
     private final PostCustomRepository postCustomRepository;
-    private final RecruitmentRepository recruitmentRepository;
 
     @Transactional
     public Long createPost(PostCreateReqDto postCreateReqDto) {
@@ -57,8 +56,8 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<CardResDto> findPostAll(Pageable pageable, String userId) {
-        List<Post> postList = postCustomRepository.findAll(pageable);
-        return PostMapper.INSTANCE.entityToCardResDto(postList);
+    public List<CardResDto> findPostAll(Pageable pageable, String userId, PostSearchCondition postSearchReqDto) {
+        List<Post> findAllBySearchCondition = postCustomRepository.findAllBySearchCondition(pageable, postSearchReqDto);
+        return PostMapper.INSTANCE.entityToCardResDto(findAllBySearchCondition);
     }
 }

--- a/src/main/java/com/justcodeit/moyeo/study/application/post/PostService.java
+++ b/src/main/java/com/justcodeit/moyeo/study/application/post/PostService.java
@@ -9,8 +9,6 @@ import com.justcodeit.moyeo.study.interfaces.mapper.PostMapper;
 import com.justcodeit.moyeo.study.persistence.Post;
 import com.justcodeit.moyeo.study.persistence.PostSkill;
 import com.justcodeit.moyeo.study.persistence.repository.PostRepository;
-import com.justcodeit.moyeo.study.persistence.repository.PostSkillRepository;
-import com.justcodeit.moyeo.study.persistence.repository.RecruitmentRepository;
 import com.justcodeit.moyeo.study.persistence.repository.SkillRepository;
 import com.justcodeit.moyeo.study.persistence.repository.querydsl.PostCustomRepository;
 import lombok.RequiredArgsConstructor;
@@ -58,6 +56,6 @@ public class PostService {
     @Transactional(readOnly = true)
     public List<CardResDto> findPostAll(Pageable pageable, String userId, PostSearchCondition postSearchReqDto) {
         List<Post> findAllBySearchCondition = postCustomRepository.findAllBySearchCondition(pageable, postSearchReqDto);
-        return PostMapper.INSTANCE.entityToCardResDto(findAllBySearchCondition);
+        return PostMapper.INSTANCE.entityListToCardResDtoList(findAllBySearchCondition);
     }
 }

--- a/src/main/java/com/justcodeit/moyeo/study/application/post/PostService.java
+++ b/src/main/java/com/justcodeit/moyeo/study/application/post/PostService.java
@@ -28,8 +28,10 @@ public class PostService {
     private final PostCustomRepository postCustomRepository;
 
     @Transactional
-    public Long createPost(PostCreateReqDto postCreateReqDto) {
+    public Long createPost(PostCreateReqDto postCreateReqDto, String userId) {
         PostMapper postMapper = PostMapper.INSTANCE;
+        postCreateReqDto.setUserId(userId);
+
         Post post = postMapper.createReqDtoToEntity(postCreateReqDto);
         post.setRecruitmentList(postCreateReqDto.getRecruitmentList());
         List<PostSkill> postSkills = postCreateReqDto.getSkillIdList()
@@ -49,7 +51,7 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public PostResDto findPost(Long id) {
-        Post post = postCustomRepository.findById(id);
+        Post post = postCustomRepository.findByIdCustom(id);
         return PostMapper.INSTANCE.entityToDto(post);
     }
 

--- a/src/main/java/com/justcodeit/moyeo/study/interfaces/dto/post/PostCreateReqDto.java
+++ b/src/main/java/com/justcodeit/moyeo/study/interfaces/dto/post/PostCreateReqDto.java
@@ -27,16 +27,16 @@ public class PostCreateReqDto {
     private PostType postType;
     private ProgressType progressType;
     private RecruitStatus recruitStatus;
+    private String userId;
+    private String contactInfo;
+    @Enumerated(EnumType.STRING)
+    private PostStatus postStatus;
     @Valid
     @Size(min = 1, max = 7)
     private List<RecruitmentDto> recruitmentList;
     @Valid
     @Size(min = 1, max = 10)
     private List<Long> skillIdList;
-    private String contactInfo;
-    @Enumerated(EnumType.STRING)
-    private PostStatus postStatus;
-
     PostCreateReqDto() {
         this.recruitStatus = RecruitStatus.RECRUITING;
         this.postStatus = PostStatus.NORMAL;

--- a/src/main/java/com/justcodeit/moyeo/study/interfaces/dto/post/PostSearchCondition.java
+++ b/src/main/java/com/justcodeit/moyeo/study/interfaces/dto/post/PostSearchCondition.java
@@ -1,0 +1,15 @@
+package com.justcodeit.moyeo.study.interfaces.dto.post;
+
+import com.justcodeit.moyeo.study.model.post.RecruitStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Setter
+@Getter
+public class PostSearchCondition {
+    private String title;
+    private RecruitStatus recruitStatus;
+    private List<Long> skillList;
+}

--- a/src/main/java/com/justcodeit/moyeo/study/interfaces/mapper/PostMapper.java
+++ b/src/main/java/com/justcodeit/moyeo/study/interfaces/mapper/PostMapper.java
@@ -19,6 +19,7 @@ public interface PostMapper {
     @Mapping(target = "recruitmentList", ignore = true)
     Post createReqDtoToEntity(PostCreateReqDto postCreateReqDto);
     PostResDto entityToDto(Post post);
+    CardResDto entityToCardResDto(Post post);
     @Mapping(target = "isScrap", ignore = true)
     List<CardResDto> entityToCardResDto(List<Post> post);
     List<PostResDto> entityListToDtoList(List<Post> postList);

--- a/src/main/java/com/justcodeit/moyeo/study/interfaces/mapper/PostMapper.java
+++ b/src/main/java/com/justcodeit/moyeo/study/interfaces/mapper/PostMapper.java
@@ -19,8 +19,8 @@ public interface PostMapper {
     @Mapping(target = "recruitmentList", ignore = true)
     Post createReqDtoToEntity(PostCreateReqDto postCreateReqDto);
     PostResDto entityToDto(Post post);
-    CardResDto entityToCardResDto(Post post);
+    CardResDto entityListToCardResDtoList(Post post);
     @Mapping(target = "isScrap", ignore = true)
-    List<CardResDto> entityToCardResDto(List<Post> post);
+    List<CardResDto> entityListToCardResDtoList(List<Post> post);
     List<PostResDto> entityListToDtoList(List<Post> postList);
 }

--- a/src/main/java/com/justcodeit/moyeo/study/interfaces/mapper/PostMapper.java
+++ b/src/main/java/com/justcodeit/moyeo/study/interfaces/mapper/PostMapper.java
@@ -19,6 +19,7 @@ public interface PostMapper {
     @Mapping(target = "recruitmentList", ignore = true)
     Post createReqDtoToEntity(PostCreateReqDto postCreateReqDto);
     PostResDto entityToDto(Post post);
+    @Mapping(target = "isScrap", ignore = true)
     List<CardResDto> entityToCardResDto(List<Post> post);
     List<PostResDto> entityListToDtoList(List<Post> postList);
 }

--- a/src/main/java/com/justcodeit/moyeo/study/interfaces/resource/PostController.java
+++ b/src/main/java/com/justcodeit/moyeo/study/interfaces/resource/PostController.java
@@ -4,12 +4,14 @@ import com.justcodeit.moyeo.study.application.post.PostService;
 import com.justcodeit.moyeo.study.interfaces.dto.post.CardResDto;
 import com.justcodeit.moyeo.study.interfaces.dto.post.PostCreateReqDto;
 import com.justcodeit.moyeo.study.interfaces.dto.post.PostResDto;
+import com.justcodeit.moyeo.study.interfaces.dto.post.PostSearchCondition;
 import com.justcodeit.moyeo.study.model.jwt.UserToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,12 +40,12 @@ public class PostController {
     }
 
     @GetMapping
-    public List<CardResDto> findPostAll(Pageable pageable, @AuthenticationPrincipal UserToken userToken) {
+    public List<CardResDto> findPostAll(Pageable pageable, @AuthenticationPrincipal UserToken userToken, @ModelAttribute PostSearchCondition searchCondition) {
         String userId = "";
         if(userToken != null) {
             userId = userToken.getUserId();
         }
-        return postService.findPostAll(pageable, userId);
+        return postService.findPostAll(pageable, userId, searchCondition);
     }
 
 

--- a/src/main/java/com/justcodeit/moyeo/study/interfaces/resource/PostController.java
+++ b/src/main/java/com/justcodeit/moyeo/study/interfaces/resource/PostController.java
@@ -29,8 +29,7 @@ public class PostController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping
     public PostResDto createPost(@RequestBody @Valid PostCreateReqDto postCreateRequestDto, @AuthenticationPrincipal UserToken userToken) {
-        postCreateRequestDto.setUserId(userToken.getUserId());
-        Long postId = postService.createPost(postCreateRequestDto);
+        Long postId = postService.createPost(postCreateRequestDto, userToken.getUserId());
         return postService.findPost(postId);
     }
 

--- a/src/main/java/com/justcodeit/moyeo/study/interfaces/resource/PostController.java
+++ b/src/main/java/com/justcodeit/moyeo/study/interfaces/resource/PostController.java
@@ -24,8 +24,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostController {
     private final PostService postService;
+    @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping
-    public PostResDto createPost(@RequestBody @Valid PostCreateReqDto postCreateRequestDto) {
+    public PostResDto createPost(@RequestBody @Valid PostCreateReqDto postCreateRequestDto, @AuthenticationPrincipal UserToken userToken) {
+        postCreateRequestDto.setUserId(userToken.getUserId());
         Long postId = postService.createPost(postCreateRequestDto);
         return postService.findPost(postId);
     }
@@ -43,4 +45,6 @@ public class PostController {
         }
         return postService.findPostAll(pageable, userId);
     }
+
+
 }

--- a/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepository.java
+++ b/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface PostCustomRepository {
-    Post findById(Long id);
+    Post findByIdCustom(Long id);
     List<Post> findAllBySearchCondition(Pageable pageable, PostSearchCondition searchCondition);
 }

--- a/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepository.java
+++ b/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepository.java
@@ -1,5 +1,6 @@
 package com.justcodeit.moyeo.study.persistence.repository.querydsl;
 
+import com.justcodeit.moyeo.study.interfaces.dto.post.PostSearchCondition;
 import com.justcodeit.moyeo.study.persistence.Post;
 import org.springframework.data.domain.Pageable;
 
@@ -7,5 +8,5 @@ import java.util.List;
 
 public interface PostCustomRepository {
     Post findById(Long id);
-    List<Post> findAll(Pageable pageable);
+    List<Post> findAllBySearchCondition(Pageable pageable, PostSearchCondition searchCondition);
 }

--- a/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepositoryImpl.java
@@ -84,11 +84,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         }
         for (Sort.Order order : sort) {
             Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
-            switch (order.getProperty()){
-                case "id":
-                    ORDERS.add(new OrderSpecifier(direction, post.id));
-                default:
-                    break;
+            if(order.getProperty().equals("id")) {
+                ORDERS.add(new OrderSpecifier(direction, post.id));
             }
         }
         return ORDERS;

--- a/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepositoryImpl.java
@@ -1,16 +1,23 @@
 package com.justcodeit.moyeo.study.persistence.repository.querydsl;
 
+import com.justcodeit.moyeo.study.interfaces.dto.post.PostSearchCondition;
 import com.justcodeit.moyeo.study.model.post.PostStatus;
+import com.justcodeit.moyeo.study.model.post.RecruitStatus;
 import com.justcodeit.moyeo.study.persistence.Post;
 import com.justcodeit.moyeo.study.persistence.QPost;
 import com.justcodeit.moyeo.study.persistence.QPostSkill;
 import com.justcodeit.moyeo.study.persistence.QRecruitment;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Repository
@@ -18,11 +25,12 @@ import java.util.List;
 public class PostCustomRepositoryImpl implements PostCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
+    QPost post = QPost.post;
+    QRecruitment recruitment = QRecruitment.recruitment;
+    QPostSkill postSkill = QPostSkill.postSkill;
+
     @Override
     public Post findById(Long id) {
-        QPost post = QPost.post;
-        QRecruitment recruitment = QRecruitment.recruitment;
-        QPostSkill postSkill = QPostSkill.postSkill;
 
         return jpaQueryFactory.selectFrom(post)
                 .leftJoin(recruitment)
@@ -35,19 +43,19 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     }
 
     @Override
-    public List<Post> findAll(Pageable pageable) {
-        QPost post = QPost.post;
-        QRecruitment recruitment = QRecruitment.recruitment;
-        QPostSkill postSkill = QPostSkill.postSkill;
+    public List<Post> findAllBySearchCondition(Pageable pageable, PostSearchCondition searchCondition) {
 
         return jpaQueryFactory.selectFrom(post)
-                .leftJoin(recruitment)
-                    .on(recruitment.post.id.eq(post.id))
+                .innerJoin(recruitment)
+                .on(recruitment.post.id.eq(post.id))
                 .leftJoin(postSkill)
-                    .on(postSkill.post.id.eq(post.id))
-                .where(gtPostId(pageable.getOffset()))
-                .fetchJoin()
+                .on(postSkill.post.id.eq(post.id))
+                .where(gtPostId(pageable.getOffset())
+                        .and(createSearchCondition(searchCondition)))
                 .limit(pageable.getPageSize())
+                .orderBy(postSort(pageable.getSort()).toArray(OrderSpecifier[]::new))
+                .fetchJoin()
+                .distinct()
                 .fetch();
     }
 
@@ -57,7 +65,37 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         }
         return QPost.post.id.gt(postId);
     }
-    private BooleanExpression defaultShow() {
-        return null;
+    private BooleanExpression createSearchCondition(PostSearchCondition postSearchReqDto) {
+        BooleanExpression expression = post.postStatus.eq(PostStatus.NORMAL);
+
+        if(StringUtils.hasText(postSearchReqDto.getTitle())) {
+            String title = postSearchReqDto.getTitle();
+            expression = expression.and(post.title.like(title + "%"));
+        }
+        if(postSearchReqDto.getRecruitStatus() != null) {
+            RecruitStatus recruitStatus = postSearchReqDto.getRecruitStatus();
+            expression = expression.and(post.recruitStatus.eq(recruitStatus));
+        }
+        if(postSearchReqDto.getSkillList() != null || postSearchReqDto.getSkillList().size() != 0) {
+            List<Long> skillList = postSearchReqDto.getSkillList();
+            expression = expression.andAnyOf(postSkill.skill.id.in(skillList));
+        }
+        return expression;
+    }
+
+    private List<OrderSpecifier> postSort(Sort sort) {
+        List<OrderSpecifier> ORDERS = new ArrayList<>();
+        if (!sort.isEmpty()) {
+            for (Sort.Order order : sort) {
+                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+                switch (order.getProperty()){
+                    case "id":
+                        ORDERS.add(new OrderSpecifier(direction, post.id));
+                    default:
+                        break;
+                }
+            }
+        }
+        return ORDERS;
     }
 }

--- a/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepositoryImpl.java
@@ -44,12 +44,11 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
     @Override
     public List<Post> findAllBySearchCondition(Pageable pageable, PostSearchCondition searchCondition) {
-
         return jpaQueryFactory.selectFrom(post)
-                .innerJoin(recruitment)
-                .on(recruitment.post.id.eq(post.id))
+                .leftJoin(recruitment)
+                    .on(recruitment.post.id.eq(post.id))
                 .leftJoin(postSkill)
-                .on(postSkill.post.id.eq(post.id))
+                    .on(postSkill.post.id.eq(post.id))
                 .where(gtPostId(pageable.getOffset())
                         .and(createSearchCondition(searchCondition)))
                 .limit(pageable.getPageSize())
@@ -76,7 +75,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
             RecruitStatus recruitStatus = postSearchReqDto.getRecruitStatus();
             expression = expression.and(post.recruitStatus.eq(recruitStatus));
         }
-        if(postSearchReqDto.getSkillList() != null || postSearchReqDto.getSkillList().size() != 0) {
+        if(postSearchReqDto.getSkillList() != null && postSearchReqDto.getSkillList().size() != 0) {
             List<Long> skillList = postSearchReqDto.getSkillList();
             expression = expression.andAnyOf(postSkill.skill.id.in(skillList));
         }

--- a/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepositoryImpl.java
@@ -79,15 +79,16 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
     private List<OrderSpecifier> postSort(Sort sort) {
         List<OrderSpecifier> ORDERS = new ArrayList<>();
-        if (!sort.isEmpty()) {
-            for (Sort.Order order : sort) {
-                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
-                switch (order.getProperty()){
-                    case "id":
-                        ORDERS.add(new OrderSpecifier(direction, post.id));
-                    default:
-                        break;
-                }
+        if (sort.isEmpty()) {
+            return ORDERS;
+        }
+        for (Sort.Order order : sort) {
+            Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+            switch (order.getProperty()){
+                case "id":
+                    ORDERS.add(new OrderSpecifier(direction, post.id));
+                default:
+                    break;
             }
         }
         return ORDERS;

--- a/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepositoryImpl.java
@@ -4,9 +4,9 @@ import com.justcodeit.moyeo.study.interfaces.dto.post.PostSearchCondition;
 import com.justcodeit.moyeo.study.model.post.PostStatus;
 import com.justcodeit.moyeo.study.model.post.RecruitStatus;
 import com.justcodeit.moyeo.study.persistence.Post;
-import com.justcodeit.moyeo.study.persistence.QPost;
-import com.justcodeit.moyeo.study.persistence.QPostSkill;
-import com.justcodeit.moyeo.study.persistence.QRecruitment;
+import static com.justcodeit.moyeo.study.persistence.QPost.post;
+import static com.justcodeit.moyeo.study.persistence.QPostSkill.postSkill;
+import static com.justcodeit.moyeo.study.persistence.QRecruitment.recruitment;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -25,13 +25,8 @@ import java.util.List;
 public class PostCustomRepositoryImpl implements PostCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
-    QPost post = QPost.post;
-    QRecruitment recruitment = QRecruitment.recruitment;
-    QPostSkill postSkill = QPostSkill.postSkill;
-
     @Override
-    public Post findById(Long id) {
-
+    public Post findByIdCustom(Long id) {
         return jpaQueryFactory.selectFrom(post)
                 .leftJoin(recruitment)
                     .on(recruitment.post.id.eq(post.id))
@@ -62,7 +57,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         if(postId == null) {
             return null;
         }
-        return QPost.post.id.gt(postId);
+        return post.id.gt(postId);
     }
     private BooleanExpression createSearchCondition(PostSearchCondition postSearchReqDto) {
         BooleanExpression expression = post.postStatus.eq(PostStatus.NORMAL);


### PR DESCRIPTION
검색 기능 추가

- 이슈 : MapStruct 사용시 Transaction이 걸려있기 때문에 Lazy로딩 시  PostSkill, Recruitment 엔티티에 대해 조회 쿼리를 보냄.
Post에서 Recruitment가 2개, PostSkill이 3개일 시 Post Entity를 1개 조회할 시  Post 1 * Recruitment 2 * PostSkill 3 = 데카르트 곱인 6개의 쿼리를 보냄. 
-> 수정: MapStruct 사용시가 아니어도 데카르트 곱 됨, 연관관계 갯수 때문에 

해결하려 fetchJoin을 사용하려고 하면 fetchJoin은 @XXXToMany 1개에 대해서만 적용이 되고 2개 이상일 시 Multi bags Fetch exception 예외가 발생.  
자료형을 List가 아닌 Set으로 맞추는게 가장 간단한 방법이지만, Set으로 바꾼다고 해도 데카르트 곱은 일어난다고 함.
때문에 default batch size 조정을 통함.

application-local.yml에 
jpa:
    properties:
      hibernate:
        default_batch_fetch_size: 100
추가 요망.