### PR TITLE
Post 전체 가져오기 API 수정

### DIFF
--- a/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepositoryImpl.java
@@ -101,6 +101,11 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .limit(pageable.getPageSize())
                 .fetch();
 
+        Long count = jpaQueryFactory.select(post.count())
+                .from(post)
+                .where(createSearchCondition(searchCondition))
+                .fetchOne();
+
         List<Long> postIds = extractPostIds(postDtoList);
 
         List<PostSkillResponseDto> postSkillDtoList = jpaQueryFactory
@@ -126,7 +131,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .fetch();
 
         combineIntoOne(postDtoList, postSkillDtoList);
-        return new PageImpl<>(postDtoList, pageable, postDtoList.size());
+        return new PageImpl<>(postDtoList, pageable, count);
     }
 
     @Override


### PR DESCRIPTION
- PageImpl에 postDtoList.size 가 있으면 PageImpl이 총 갯수를 해당 갯수로 생각함.
따라서 전체 갯수를 세는 쿼리문이 필요