### PR TITLE
Post 전체 가져오기 API 수정

### DIFF
--- a/src/main/java/com/justcodeit/moyeo/study/application/post/PostService.java
+++ b/src/main/java/com/justcodeit/moyeo/study/application/post/PostService.java
@@ -68,8 +68,8 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PostQueryDto> findPostAll(Pageable pageable, String userId, PostSearchCondition postSearchReqDto) {
-        return postRepository.findPostList(userId, postSearchReqDto, pageable);
+    public Page<PostQueryDto> findPostAll(Pageable pageable, Long lastPostId, String userId, PostSearchCondition postSearchReqDto) {
+        return postRepository.findPostList(userId, lastPostId,postSearchReqDto, pageable);
     }
 
     @Transactional

--- a/src/main/java/com/justcodeit/moyeo/study/interfaces/resource/PostController.java
+++ b/src/main/java/com/justcodeit/moyeo/study/interfaces/resource/PostController.java
@@ -36,6 +36,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
@@ -93,14 +94,15 @@ public class PostController {
             @ApiResponse(responseCode = "200", description = "success")
     })
     @GetMapping
-    public Page<PostQueryDto> findPostAll(@Parameter(hidden = true) Pageable pageable,
-                                          @Parameter(hidden = true) @AuthenticationPrincipal UserToken userToken,
-                                          @ParameterObject @ModelAttribute PostSearchCondition searchCondition) {
+    public Page<PostQueryDto> findPostAll(@Parameter(name = "last") @RequestParam(name = "last") Long lastPostId,
+                                            @Parameter(hidden = true) Pageable pageable,
+                                            @Parameter(hidden = true) @AuthenticationPrincipal UserToken userToken,
+                                            @ParameterObject @ModelAttribute PostSearchCondition searchCondition) {
         String userId = "";
         if(userToken != null) {
             userId = userToken.getUserId();
         }
-        return postService.findPostAll(pageable, userId, searchCondition);
+        return postService.findPostAll(pageable,lastPostId, userId, searchCondition);
     }
 
     @Operation(summary = "모집글 모집 상태 변경", description = "모집글의 모집 상태를 변경한다. ex) 모집중 -> 모집완료")

--- a/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepository.java
+++ b/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepository.java
@@ -14,6 +14,6 @@ public interface PostCustomRepository {
     Optional<Post> findByIdCustom(Long id);
     List<Post> findAllBySearchCondition(Pageable pageable, PostSearchCondition searchCondition);
     boolean existByIdAndUserIdAndPostStatusNormal(Long id, String userId, PostStatus postStatus);
-    Page<PostQueryDto> findPostList(String userId, PostSearchCondition searchCondition, Pageable pageable);
+    Page<PostQueryDto> findPostList(String userId, Long lastPostId, PostSearchCondition searchCondition, Pageable pageable);
     List<PostQueryDto> findPostListByUserId(String userId);
 }

--- a/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/justcodeit/moyeo/study/persistence/repository/querydsl/PostCustomRepositoryImpl.java
@@ -60,7 +60,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .on(recruitment.post.id.eq(post.id))
                 .leftJoin(postSkill)
                 .on(postSkill.post.id.eq(post.id))
-                .where(gtPostId(pageable.getOffset())
+                .where(ltPostId(pageable.getOffset())
                         .and(createSearchCondition(searchCondition)))
                 .limit(pageable.getPageSize())
                 .orderBy(postSort(pageable.getSort()).toArray(OrderSpecifier[]::new))
@@ -82,7 +82,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     }
 
     @Override
-    public Page<PostQueryDto> findPostList(String userId, PostSearchCondition searchCondition, Pageable pageable) {
+    public Page<PostQueryDto> findPostList(String userId, Long lastPostId, PostSearchCondition searchCondition, Pageable pageable) {
         List<PostQueryDto> postDtoList = jpaQueryFactory
                 .select(new QPostQueryDto(
                         post.id,
@@ -96,7 +96,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 ))
                 .from(post)
                 .leftJoin(scrap).on(post.id.eq(scrap.postId))
-                .where(gtPostId(pageable.getOffset()), createSearchCondition(searchCondition))
+                .where(ltPostId(lastPostId), createSearchCondition(searchCondition))
                 .orderBy(postSort(pageable.getSort()).toArray(OrderSpecifier[]::new))
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -177,11 +177,11 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         return postDtoList;
     }
 
-    private BooleanExpression gtPostId(Long postId) {
-        if(postId == null) {
+    private BooleanExpression ltPostId(Long lastPostId) {
+        if(lastPostId == null || lastPostId == 0) {
             return null;
         }
-        return post.id.gt(postId);
+        return post.id.lt(lastPostId);
     }
     private BooleanExpression createSearchCondition(PostSearchCondition postSearchReqDto) {
         BooleanExpression expression = post.postStatus.eq(PostStatus.NORMAL);


### PR DESCRIPTION
- 목록 가져올 때 마지막 postid를 가져와서 검색.
- 해당 페이지의 조회 성능을 높이려고 함.